### PR TITLE
Load increase rework

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val spring_boot_starter_version = "3.0.4"
-val dqlang_version = "0.2.1"
+val dqlang_version = "0.3.0"
 
 plugins {
     id("org.springframework.boot") version "3.1.0-M2"
@@ -83,6 +83,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0-Beta")
     implementation("org.mapstruct:mapstruct:1.5.3.Final")
+    implementation("org.springframework.vault:spring-vault-core:3.0.2")
 
     implementation("dqualizer:dqlang:$dqlang_version")
 

--- a/src/main/kotlin/dqualizer/dqexec/adapter/StimulusAdapter.kt
+++ b/src/main/kotlin/dqualizer/dqexec/adapter/StimulusAdapter.kt
@@ -1,10 +1,15 @@
 package dqualizer.dqexec.adapter
 
+import dqualizer.dqexec.util.LoadCurveHelper
 import dqualizer.dqlang.archive.k6adapter.dqlang.constants.LoadTestConstants
 import dqualizer.dqlang.archive.k6adapter.dqlang.k6.Stage
 import dqualizer.dqlang.archive.k6adapter.dqlang.k6.options.*
 import dqualizer.dqlang.archive.k6adapter.dqlang.loadtest.Stimulus
 import org.springframework.stereotype.Component
+import org.springframework.vault.support.DurationParser
+import java.time.Duration
+import java.util.*
+import kotlin.math.roundToInt
 
 /**
  * Adapts the stimulus to a k6 'options' object
@@ -133,9 +138,10 @@ class StimulusAdapter(private val loadTestConstants: LoadTestConstants) {
 
         val endTarget = loadIncrease.endTarget
         val startTarget = loadIncrease.startTarget
-        val stageDuration = loadIncrease.stageDuration
+        val numberOfStages = loadIncrease.stages
+        val testDuration: String = loadIncrease.testDuration
 
-        val stages = this.getIncreasingStages(stageDuration, startTarget, endTarget, exponent)
+        val stages = getIncreasingStages(startTarget, endTarget, exponent, testDuration, numberOfStages)
         return RampingScenario(stages)
     }
 
@@ -148,33 +154,42 @@ class StimulusAdapter(private val loadTestConstants: LoadTestConstants) {
     /**
      * Create an ordered set of stages for the 'INCREASE_LOAD' load_profile
      *
-     * @param stageDuration The duration of one single stage
-     * @param startTarget   The amount of users at the first stage
-     * @param endTarget     The amount of users at the last stage
-     * @param exponent      How fast should the amount of users increase
+     * @param startTarget The amount of users at the first stage
+     * @param endTarget   The amount of users at the last stage
+     * @param exponent    How fast should the amount of users increase
      * @return An ordered set of stages
      */
     private fun getIncreasingStages(
-        stageDuration: String,
-        startTarget: Int,
-        endTarget: Int,
-        exponent: Int
+        startTarget: Int, endTarget: Int, exponent: Int,
+        testDurationString: String, numberOfStages: Int
     ): LinkedHashSet<Stage> {
         val stages = LinkedHashSet<Stage>()
-        var stageCounter = 1
-        var currentTarget = startTarget
-
-        while (currentTarget < endTarget) {
-            currentTarget = startTarget * Math.pow(stageCounter.toDouble(), exponent.toDouble()).toInt()
-            val currentStage = Stage(stageDuration, currentTarget)
+        val stageDurationString: String = computeStageDurationString(testDurationString, numberOfStages)
+        val loadCurve = LoadCurveHelper(exponent.toDouble(), startTarget.toDouble(), endTarget.toDouble(), numberOfStages.toDouble())
+        val firstStage = Stage("0s", startTarget)
+        stages.add(firstStage)
+        for (i in 0 until numberOfStages) {
+            val endTimeOfStage = i + 1
+            val currentStage = Stage(
+                stageDurationString,
+                loadCurve.evaluate(endTimeOfStage.toDouble()).roundToInt()
+            )
             stages.add(currentStage)
-
-            stageCounter++
         }
-        val lastStage = Stage(stageDuration, 0)
+        val lastStage = Stage(stageDurationString, 0)
         stages.add(lastStage)
-
         return stages
+    }
+
+
+    private fun computeStageDurationString(testDurationString: String, numberOfStages: Int): String {
+        val testDuration = convertToTimeString(testDurationString)
+        val testDurationSeconds = testDuration!!.seconds
+        val testDurationNanos = testDuration.nano
+        val stageDurationSeconds = testDurationSeconds / numberOfStages
+        val stageDurationNanos = (testDurationNanos / numberOfStages).toLong()
+        val stageDuration = Duration.ofSeconds(stageDurationSeconds).plusNanos(stageDurationNanos)
+        return convertToTimeString(stageDuration)
     }
 
     /**
@@ -206,7 +221,7 @@ class StimulusAdapter(private val loadTestConstants: LoadTestConstants) {
         val minDuration = constantLoad.minDuration
 
         val duration = (maxDuration * (accuracy / 100.0)).toInt()
-        val trueDuration = Math.max(minDuration, duration)
+        val trueDuration = minDuration.coerceAtLeast(duration)
 
         return ConstantScenario(vus, trueDuration)
     }
@@ -215,5 +230,13 @@ class StimulusAdapter(private val loadTestConstants: LoadTestConstants) {
         LOW,
         MEDIUM,
         HIGH
+    }
+
+    private fun convertToTimeString(timeString: String): Duration? {
+        return Objects.requireNonNull(DurationParser.parseDuration(timeString))
+    }
+
+    private fun convertToTimeString(duration: Duration): String {
+        return DurationParser.formatDuration(duration)
     }
 }

--- a/src/main/kotlin/dqualizer/dqexec/util/LoadCurveHelper.kt
+++ b/src/main/kotlin/dqualizer/dqexec/util/LoadCurveHelper.kt
@@ -1,0 +1,52 @@
+package dqualizer.dqexec.util
+
+import kotlin.math.pow
+
+/**
+ * A helper class that calculates points on a load curve of the format y=t^e with e being the exponent.
+ * @param exponent the exponent of the base function
+ * @param ymin     the minimum y value
+ * @param ymax     the maxmium y value
+ * @param targetDuration the duration of the load profile.
+ */
+class LoadCurveHelper(exponent: Double, ymin: Double, ymax: Double, targetDuration: Double) {
+    private val exponent: Double
+    private val startOnBaseFunction: Double
+    private val baseFunctionDuration: Double
+    private val targetDuration: Double
+
+    init {
+        require(exponent >= 1) { "Exponent needs to be at least 1, but was: $exponent" }
+        require(ymin >= 0) { "Minimum y needs to be at least 0, but was: $ymin" }
+        require(ymax >= ymin) { "Maximum y must be bigger than Minimum y ($ymin), but was: $ymax" }
+        require(targetDuration > 0) { "Target Duration needs to be bigger than 0, but was: $exponent" }
+        this.exponent = exponent
+        startOnBaseFunction = ymin.pow(1.0 / exponent)
+        val endOnBaseFunction = ymax.pow(1.0 / exponent)
+        baseFunctionDuration = endOnBaseFunction - startOnBaseFunction
+        this.targetDuration = targetDuration
+    }
+
+    /**
+     * Returns y of the base function y=t^e for a given time t.
+     *
+     * @param time a point in time
+     * @return y
+     */
+    private fun evaluateBaseFunction(time: Double): Double {
+        return time.pow(exponent)
+    }
+
+    /**
+     * Returns the value for a given point in time for a load profile of given length "duration" and with the form
+     * y=t^e with e being an exponent defined at initalization. At the beginning (time = 0) the value is ymin and at
+     * the end (time = duration) the value is ymax.
+     *
+     * @param time     the time, a value between 0 and duration
+     * @return a value between ymin and ymax as defined at initialization.
+     */
+    fun evaluate(time: Double): Double {
+        val mappedTime = startOnBaseFunction + baseFunctionDuration / targetDuration * time
+        return evaluateBaseFunction(mappedTime)
+    }
+}

--- a/src/main/resources/constant/constants.json
+++ b/src/main/resources/constant/constants.json
@@ -17,8 +17,9 @@
     },
     "load_increase": {
       "start_target": 10,
-      "end_target": 60,
-      "stage_duration": "5s",
+      "end_target": 200,
+      "test_duration": "30s",
+      "stages": 10,
       "linear": 1,
       "quadratic": 2,
       "cubic": 3

--- a/src/test/kotlin/dqualizer/dqexec/util/LoadCurveHelperTest.kt
+++ b/src/test/kotlin/dqualizer/dqexec/util/LoadCurveHelperTest.kt
@@ -1,0 +1,32 @@
+package dqualizer.dqexec.util
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class LoadCurveHelperTest {
+    @Test
+    fun testTrivialLoadCurve() {
+        val computer = LoadCurveHelper(2.0, 0.0, 9.0, 3.0)
+        Assertions.assertEquals(0.0, computer.evaluate(0.0))
+        Assertions.assertEquals(1.0, computer.evaluate(1.0))
+        Assertions.assertEquals(4.0, computer.evaluate(2.0))
+        Assertions.assertEquals(9.0, computer.evaluate(3.0))
+    }
+
+    @Test
+    fun testShiftedTrivialLoadCurve() {
+        val computer = LoadCurveHelper(2.0, 1.0, 16.0, 3.0)
+        Assertions.assertEquals(1.0, computer.evaluate(0.0))
+        Assertions.assertEquals(4.0, computer.evaluate(1.0))
+        Assertions.assertEquals(9.0, computer.evaluate(2.0))
+        Assertions.assertEquals(16.0, computer.evaluate(3.0))
+    }
+
+    @Test
+    fun testSqueezedLoadCurve() {
+        val computer = LoadCurveHelper(2.0, 0.0, 16.0, 2.0)
+        Assertions.assertEquals(0.0, computer.evaluate(0.0))
+        Assertions.assertEquals(4.0, computer.evaluate(1.0))
+        Assertions.assertEquals(16.0, computer.evaluate(2.0))
+    }
+}

--- a/src/test/kotlin/dqualizer/dqexec/util/LoadCurveHelperTest.kt
+++ b/src/test/kotlin/dqualizer/dqexec/util/LoadCurveHelperTest.kt
@@ -1,32 +1,57 @@
 package dqualizer.dqexec.util
 
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class LoadCurveHelperTest {
     @Test
     fun testTrivialLoadCurve() {
         val computer = LoadCurveHelper(2.0, 0.0, 9.0, 3.0)
-        Assertions.assertEquals(0.0, computer.evaluate(0.0))
-        Assertions.assertEquals(1.0, computer.evaluate(1.0))
-        Assertions.assertEquals(4.0, computer.evaluate(2.0))
-        Assertions.assertEquals(9.0, computer.evaluate(3.0))
+        assertEquals(0.0, computer.evaluate(0.0))
+        assertEquals(1.0, computer.evaluate(1.0))
+        assertEquals(4.0, computer.evaluate(2.0))
+        assertEquals(9.0, computer.evaluate(3.0))
     }
 
     @Test
     fun testShiftedTrivialLoadCurve() {
         val computer = LoadCurveHelper(2.0, 1.0, 16.0, 3.0)
-        Assertions.assertEquals(1.0, computer.evaluate(0.0))
-        Assertions.assertEquals(4.0, computer.evaluate(1.0))
-        Assertions.assertEquals(9.0, computer.evaluate(2.0))
-        Assertions.assertEquals(16.0, computer.evaluate(3.0))
+        assertEquals(1.0, computer.evaluate(0.0))
+        assertEquals(4.0, computer.evaluate(1.0))
+        assertEquals(9.0, computer.evaluate(2.0))
+        assertEquals(16.0, computer.evaluate(3.0))
     }
 
     @Test
     fun testSqueezedLoadCurve() {
         val computer = LoadCurveHelper(2.0, 0.0, 16.0, 2.0)
-        Assertions.assertEquals(0.0, computer.evaluate(0.0))
-        Assertions.assertEquals(4.0, computer.evaluate(1.0))
-        Assertions.assertEquals(16.0, computer.evaluate(2.0))
+        assertEquals(0.0, computer.evaluate(0.0))
+        assertEquals(4.0, computer.evaluate(1.0))
+        assertEquals(16.0, computer.evaluate(2.0))
+    }
+
+    @Test
+    fun throwsIllegalArgumentExceptionOnExponentSmallerThan1() {
+        assertThrows<IllegalArgumentException> {
+            LoadCurveHelper(0.0, 0.0, 1.0, 1.0)
+        }
+        assertThrows<IllegalArgumentException> {
+            LoadCurveHelper(-1.0, 0.0, 1.0, 1.0)
+        }
+    }
+
+    @Test
+    fun throwsIllegalArgumentExceptionOnYMinLargerYMax() {
+        assertThrows<IllegalArgumentException> {
+            LoadCurveHelper(2.0, 1.0, 0.0, 3.0)
+        }
+    }
+
+    @Test
+    fun throwsIllegalArgumentExceptionOnNegativeDuration(){
+        assertThrows<IllegalArgumentException> {
+            LoadCurveHelper(2.0, 1.0, 0.0, -3.0)
+        }
     }
 }


### PR DESCRIPTION
Content:
The change concerns the test generation for load increase RQAs. In essence, the improvements are:
- The load profile no longer determines the duration of the test, but the load profile is fitted to a specified test duration
- The new load profile is more accurate, i.e., it does not set higher request numbers than the specified max amount of requests (which usually happened in the previous implementation in the last stage)
- The number of stages in the load profile can be specified, allowing for more control of the load profile's smoothness

These are changes I implemented at the Hackathon - I hope the Java-2-Kotlin transformation did a good job ;D

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dqualizer/dqexec/18)
<!-- Reviewable:end -->
